### PR TITLE
Add __init__ file and fix arty pullup constraints

### DIFF
--- a/example_designs/arty.py
+++ b/example_designs/arty.py
@@ -31,8 +31,8 @@ from litescope import LiteScopeAnalyzer
 
 _sd_io = [
     ("sdcard", 0,
-        Subsignal("data", Pins("V11 T13 U13 U12"), Misc("PULLUP")),
-        Subsignal("cmd", Pins("V10"), Misc("PULLUP")),
+        Subsignal("data", Pins("V11 T13 U13 U12"), Misc("PULLUP True")),
+        Subsignal("cmd", Pins("V10"), Misc("PULLUP True")),
         Subsignal("clk", Pins("V12")),
         IOStandard("LVCMOS33"), Misc("SLEW=FAST")
     )


### PR DESCRIPTION
Without __init__.py file, setup.py doesn't install the package