### PR TITLE
Fix for arty

### DIFF
--- a/examples/arty.py
+++ b/examples/arty.py
@@ -102,8 +102,8 @@ class SDSoC(SoCCore):
 
         # bridge
         if not with_cpu:
-            self.add_cpu_or_bridge(UARTWishboneBridge(platform.request("serial"), clk_freq, baudrate=115200))
-            self.add_wb_master(self.cpu_or_bridge.wishbone)
+            self.add_cpu(UARTWishboneBridge(platform.request("serial"), clk_freq, baudrate=115200))
+            self.add_wb_master(self.cpu.wishbone)
 
         # emulator
         if with_emulator:

--- a/litesdcard/firmware/Makefile
+++ b/litesdcard/firmware/Makefile
@@ -18,7 +18,7 @@ firmware.elf: $(OBJECTS)
 	$(LD) $(LDFLAGS) \
 		-T linker.ld \
 		-N -o $@ \
-		 $(BUILD_DIR)/software/libbase/crt0-$(CPU).o \
+		 $(BUILD_DIR)/software/libbase/crt0-$(CPU)-ctr.o \
 		$(OBJECTS) \
 		-L$(BUILD_DIR)/software/libbase \
 		-L$(BUILD_DIR)/software/libcompiler_rt \

--- a/test/libbase/sdcard.py
+++ b/test/libbase/sdcard.py
@@ -30,18 +30,18 @@ def sdclks7_set_config(wb, freq):
     clock_m, clock_d = sdclks7_get_config(freq//1000)
     # clkfbout_mult = clock_m
     if(clock_m%2):
-        sdclk_mmcm_write(wb, 0x14, 0x1000 | ((clock_m//2)<<6) | (clock_m//2 + 1))
+        sdclks7_mmcm_write(wb, 0x14, 0x1000 | ((clock_m//2)<<6) | (clock_m//2 + 1))
     else:
-        sdclk_mmcm_write(wb, 0x14, 0x1000 | ((clock_m//2)<<6) | clock_m//2)
+        sdclks7_mmcm_write(wb, 0x14, 0x1000 | ((clock_m//2)<<6) | clock_m//2)
     # divclk_divide = clock_d
     if (clock_d == 1):
-        sdclk_mmcm_write(wb, 0x16, 0x1000)
+        sdclks7_mmcm_write(wb, 0x16, 0x1000)
     elif(clock_d%2):
-        sdclk_mmcm_write(wb, 0x16, ((clock_d//2)<<6) | (clock_d//2 + 1))
+        sdclks7_mmcm_write(wb, 0x16, ((clock_d//2)<<6) | (clock_d//2 + 1))
     else:
-        sdclk_mmcm_write(wb, 0x16, ((clock_d//2)<<6) | clock_d//2)
+        sdclks7_mmcm_write(wb, 0x16, ((clock_d//2)<<6) | clock_d//2)
     # clkout0_divide = 10
-    sdclk_mmcm_write(wb, 0x8, 0x1000 | (5<<6) | 5)
+    sdclks7_mmcm_write(wb, 0x8, 0x1000 | (5<<6) | 5)
 
 
 CLKGEN_STATUS_BUSY = 0x1

--- a/test/libbase/sdcard.py
+++ b/test/libbase/sdcard.py
@@ -27,7 +27,7 @@ def sdclks7_get_config(freq):
     return best_m, best_d
 
 def sdclks7_set_config(wb, freq):
-    clock_m, clock_d = sdclk_get_config(freq//1000)
+    clock_m, clock_d = sdclks7_get_config(freq//1000)
     # clkfbout_mult = clock_m
     if(clock_m%2):
         sdclk_mmcm_write(wb, 0x14, 0x1000 | ((clock_m//2)<<6) | (clock_m//2 + 1))

--- a/test/test_identifier.py
+++ b/test/test_identifier.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from litex.soc.tools.remote import RemoteClient
+from litex import RemoteClient
 
 wb = RemoteClient()
 wb.open()

--- a/test/test_sdcard.py
+++ b/test/test_sdcard.py
@@ -3,7 +3,7 @@
 import sys
 import time
 
-from litex.soc.tools.remote import RemoteClient
+from litex import RemoteClient
 
 from libbase.sdcard import *
 


### PR DESCRIPTION
Hello,

While trying the test code on litesdcard on the Arty I found some bitrot(I think).After my changes the wishbone test code works and so does building of the firmware. Please review 
TEST code output:
```
CMD0: GO_IDLE_STATE
CMD8: SEND_EXT_CSD
cmdevt: 0x00000001
0x000001aa
CMD55: APP_CMD
cmdevt: 0x00000001
0x00000120
CMD41: APP_SEND_OP_COND
cmdevt: 0x00000009 (CRC Error)
0x00ff8000
CMD55: APP_CMD
cmdevt: 0x00000001
0x00000120
CMD41: APP_SEND_OP_COND
cmdevt: 0x00000009 (CRC Error)
0xc0ff8000
SDCard ready | 1.8V switch not supported/needed
CMD2: ALL_SEND_CID
cmdevt: 0x00000001
0x00275048 0x53443332 0x4730dae9 0xc3320102
CMD3: SET_RELATIVE_ADDRESS
cmdevt: 0x00000001
0x00070500
RCA: 0007
CMD10: SEND_CID
cmdevt: 0x00000001
0x00275048 0x53443332 0x4730dae9 0xc3320102

    CID Register: 0x275048534433324730dae9c3320102
    Manufacturer ID: 0x27
    Application ID: 0x5048
    Product name: b'SD32G'
    Product revision: 0x30
    Product serial number: 0xdae9c332

CMD9: SEND_CSD
cmdevt: 0x00000001
0x00400e00 0x325b5900 0x00e7bf7f 0x800a4000

    CSD Register: 0x400e00325b590000e7bf7f800a4000
    CSD Structure: CSD version 2.0
    Max data transfer rate: 50 MB/s
    Max read block length: 512 bytes
    Device size: 28.96875 GB

CMD7: SELECT_CARD
cmdevt: 0x00000001
0x00000700
CMD55: APP_CMD
cmdevt: 0x00000001
0x00000920
CMD6: APP_SET_BUS_WIDTH
cmdevt: 0x00000001
0x00000920
CMD55: APP_CMD
cmdevt: 0x00000001
0x00000920
CMD51: APP_SEND_SCR
cmdevt: 0x00000001
0x00000920
dataevt: 0x00000001
CMD16: SET_BLOCKLEN
cmdevt: 0x00000001
0x00000900
CMD24: WRITE_SINGLE_BLOCK
cmdevt: 0x00000001
CMD17: READ_SINGLE_BLOCK
cmdevt: 0x00000001
bist errors: 0
CMD24: WRITE_SINGLE_BLOCK
cmdevt: 0x00000001
CMD17: READ_SINGLE_BLOCK
cmdevt: 0x00000001
bist errors: 0
CMD23: SET_BLOCK_COUNT
cmdevt: 0x00000001
0x00800900
CMD25: WRITE_MULTIPLE_BLOCK
cmdevt: 0x00000001
CMD12: STOP_TRANSMISSION
cmdevt: 0x00000001
0x00000c00
CMD23: SET_BLOCK_COUNT
cmdevt: 0x0000000d (CRC Error) (Timeout)
0x00000000
CMD18: READ_MULTIPLE_BLOCK
cmdevt: 0x0000000d (CRC Error) (Timeout)
cmdevt: 0x00000001
bist errors: 3145856
```

FIRMWARE:
```
[LXTERM] Starting....

        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|

 (c) Copyright 2012-2019 Enjoy-Digital
 (c) Copyright 2012-2015 M-Labs Ltd

 BIOS built on Jun 14 2019 15:02:02
 BIOS CRC passed (1cb8242d)

--============ SoC info ================--
CPU:       LM32 @ 100MHz
ROM:       32KB
SRAM:      4KB
MAIN-RAM:  32KB

--========= Peripherals init ===========--

--========== Boot sequence =============--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
[LXTERM] Received firmware download request from the device.
[LXTERM] Uploading firmware.bin (11192 bytes)...
[LXTERM] Upload complete (7.7KB/s).
[LXTERM] Booting the device.
[LXTERM] Done.
Executing booted program at 0x40000000

LiteSDCard CPU testing software built Jun 12 2019 10:20:06
Available commands:
help           - this command
reboot         - reboot CPU
sdclk <freq>   - SDCard set clk frequency (Mhz)
sdinit         - SDCard initialization
sdtest <loops> - SDCard test
RUNTIME>sdclk 10
RUNTIME>sdinit
RUNTIME>sdtest 1
LOOP WRITE_SPEED  READ_SPEED ERRORS
   0      3 MB/s      4 MB/s 830179

```