### PR TITLE
Fix compilation warning ‘errors’ may be used uninitialized.

### DIFF
--- a/litesdcard/firmware/sdcard.c
+++ b/litesdcard/firmware/sdcard.c
@@ -658,7 +658,7 @@ int sdcard_test(unsigned int loops) {
 	unsigned int blocks;
 	unsigned int start;
 	unsigned int end;
-	unsigned int errors;
+	unsigned int errors = 0;
 	unsigned long write_speed, read_speed;
 
 	sdcore_cmdtimeout_write(1<<19);


### PR DESCRIPTION
sdcard.c:709:9: warning: ‘errors’ may be used uninitialized in this function [-Wmaybe-uninitialized]