### PR TITLE
cleanup: CSR accessors and global variable in header

### DIFF
--- a/litesdcard/firmware/sdcard.c
+++ b/litesdcard/firmware/sdcard.c
@@ -557,6 +557,8 @@ void sdcard_bist_checker_wait(void) {
 /* user */
 
 int sdcard_init(void) {
+	unsigned short rca;
+
         /* initialize SD driver parameters */
 	sdcore_cmdtimeout_write(1<<19);
 	sdcore_datatimeout_write(1<<19);

--- a/litesdcard/firmware/sdcard.h
+++ b/litesdcard/firmware/sdcard.h
@@ -44,8 +44,6 @@
 #define SDCARD_CTRL_RESPONSE_SHORT 1
 #define SDCARD_CTRL_RESPONSE_LONG  2
 
-unsigned short rca;
-
 /* clocking */
 
 void sdclk_set_clk(unsigned int freq);


### PR DESCRIPTION
1. clean up SDCORE_RESPONSE read access (use new array accessor available in LiteX)

2. remove global variable definition from header file, make it local to the (only) function that references it.