### PR TITLE
Add pin to detect sdcard presence in card reader slot.

### DIFF
--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -16,7 +16,7 @@ from litesdcard.crc import CRCDownstreamChecker, CRCUpstreamInserter
 
 
 class SDCore(Module, AutoCSR):
-    def __init__(self, phy, csr_data_width=32):
+    def __init__(self, phy, carddetect_pin=None, csr_data_width=32):
         self.sink = stream.Endpoint([("data", 32)])
         self.source = stream.Endpoint([("data", 32)])
 
@@ -40,7 +40,14 @@ class SDCore(Module, AutoCSR):
         self.datawcrcvalids = CSRStatus(32)
         self.datawcrcerrors = CSRStatus(32)
 
+        self.cardcd = CSRStatus()
         # # #
+
+        if carddetect_pin is not None:
+            self.comb += self.cardcd.status.eq(carddetect_pin)
+        else:
+            # If we do not have pin to detect card presence, we are assuming, that card is always present
+            self.cardcd = CSRConstant(0)
 
         argument = Signal(32)
         command = Signal(32)


### PR DESCRIPTION
This adds a new CSR exposing a bit indicating if the card is present.
If there is no card detection pin available in the HW it's assume that the card is inserted.