### PR TITLE
Remove unused carddetect_pin parameter

### DIFF
--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -16,7 +16,7 @@ from litesdcard.crc import CRCDownstreamChecker, CRCUpstreamInserter
 
 
 class SDCore(Module, AutoCSR):
-    def __init__(self, phy, carddetect_pin=None, csr_data_width=32):
+    def __init__(self, phy, csr_data_width=32):
         self.sink = stream.Endpoint([("data", 32)])
         self.source = stream.Endpoint([("data", 32)])
 


### PR DESCRIPTION
Just a small fix - removing an unused constructor parameter left after the refactor.