### PR TITLE
core: expose only 128 bits of the internal response register

### DIFF
--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -25,7 +25,7 @@ class SDCore(Module, AutoCSR):
         self.command        = CSRStorage(32)
         self.send           = CSR()
 
-        self.response       = CSRStatus(136)
+        self.response       = CSRStatus(128)
 
         self.cmdevt         = CSRStatus(32)
         self.dataevt        = CSRStatus(32)
@@ -69,7 +69,7 @@ class SDCore(Module, AutoCSR):
         self.submodules += response_cdc, cmdevt_cdc, dataevt_cdc
         self.comb += [
             response_cdc.i.eq(response),
-            self.response.status.eq(response_cdc.o),
+            self.response.status.eq(response_cdc.o[:128]),
             cmdevt_cdc.i.eq(cmdevt),
             self.cmdevt.status.eq(cmdevt_cdc.o),
             dataevt_cdc.i.eq(dataevt),


### PR DESCRIPTION
While the internal response register may need 136 bits, the software side (bios and kernel) ignore the last byte, using only information provided in the first 128 bits. As such, let's only expose those
128 bits, with the advantage of re-enabling software to once again deal with CSR endianness and alignment in a sane, portable way.

NOTEs:
1. This removes https://github.com/enjoy-digital/litex/issues/546 from my "critical path" (should still be dealt with, but orthogonally to this, and no longer an emergency... :) )
2. Tested on nexys4ddr with `(mor1kx, vexriscv, rocket) x (csr_data_with \in {8, 32})`