### PR TITLE
core: fix long response register off-by-8bit shift

### DIFF
--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -133,7 +133,7 @@ class SDCore(Module, AutoCSR):
             phy.cmdr.sink.valid.eq(1),
             phy.cmdr.sink.last.eq(data_type == SDCARD_CTRL_DATA_TRANSFER_NONE),
             If(cmd_type == SDCARD_CTRL_RESPONSE_LONG,
-                phy.cmdr.sink.length.eq(17) # 136bits
+                phy.cmdr.sink.length.eq(17+1) # 136bits + 8bit shift to expose expected 128-bit window to software
             ).Else(
                 phy.cmdr.sink.length.eq(6)  # 48bits
             ),


### PR DESCRIPTION
Ensure each bit of the long (16 byte) response register is shifted
into its appropriate position (off by 8 bits before this patch).

E.g., on my 32GB sdcard, with spi-sdcard the CSD register comes back (correctly) as:

```
400e0032_5b590000_edc87f80_0a4040c3
```

However, before this patch, with litesdcard, the CSD register of the very same SDcard is shown as:

```
3f400e00_325b5900_00edc87f_800a4040
```

After the patch, the CSD register is the same as in SPI mode, which means the (long) response register should now be returned correctly, hopefully in all cases, not just when returning the CSD register :)

@enjoy-digital: I tried just shifting things into place in software (in the linux driver), and that resulted in the same behavior as this patch, so anything further that's broken is probably broken in software, and this patch should be applied anyway as-is, since it's most likely doing the right thing :)

**EDIT**: well, the least-significant byte is 0a4040**00** (instead of 0a4040**c3** -- i.e., the CRC isn't computed, but that's already a known FIXME item in litesdcard, so I'm not worried about it for now)