### PR TITLE
core: minor cosmetic cleanup

### DIFF
--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -143,6 +143,7 @@ class SDCore(Module, AutoCSR):
                     NextValue(cmd_timeout, 1),
                     NextState("IDLE")
                 ).Elif(phy.cmdr.source.last,
+                    NextValue(cmd_done, 1),
                     If(data_type == SDCARD_CTRL_DATA_TRANSFER_WRITE,
                         NextState("DATA-WRITE")
                     ).Elif(data_type == SDCARD_CTRL_DATA_TRANSFER_READ,

--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -117,7 +117,7 @@ class SDCore(Module, AutoCSR):
                     phy.cmdw.sink.last.eq(cmd_type == SDCARD_CTRL_RESPONSE_NONE)]
                }
             ),
-            If(phy.cmdw.sink.valid & phy.cmdw.sink.ready,
+            If(phy.cmdw.sink.ready,
                 NextValue(cmd_count, cmd_count + 1),
                 If(cmd_count == (6-1),
                     If(cmd_type == SDCARD_CTRL_RESPONSE_NONE,


### PR DESCRIPTION
- commit 1: The only difference is that with this patch software can learn that the command portion completed on a more timely basis, before the data transfer begins. Ultimately, when the core FSM returns to idle (at the end of the data transfer) it will assert cmd_done regardless -- we should just set it as soon as we know it completed...
- commit 2: more of a "coding style" thing: don't use a signal we ourselves hard-set to 1 as part of an "and" expression in a condition check: it's 1, we know it's 1, so even though it wil be optimized out in synthesis, it might cause the reader to wonder if there's a reason we're including it in the check :)