### PR TITLE
core/phy: Better spec compliance and interrupt support

### DIFF
--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -27,6 +27,7 @@ class SDCore(Module, AutoCSR):
         self.cmd_argument = CSRStorage(32, description="SDCard Cmd Argument.")
         self.cmd_command  = CSRStorage(32, fields=[
             CSRField("cmd_type",  offset=0, size=2, description="Core/PHY Cmd transfer type."),
+            CSRField("busy_wait", offset=2, size=1, description="Core/PHY Cmd busy wait."),
             CSRField("data_type", offset=5, size=2, description="Core/PHY Data transfer type."),
             CSRField("cmd",       offset=8, size=6, description="SDCard Cmd.")
         ])
@@ -83,12 +84,15 @@ class SDCore(Module, AutoCSR):
         data_error   = Signal()
         data_timeout = Signal()
 
+        busy_wait    = Signal()
+
         cmd          = Signal(6)
 
         self.comb += [
             # Decode type of Cmd/Data from Register.
             cmd_type.eq(self.cmd_command.fields.cmd_type),
             data_type.eq(self.cmd_command.fields.data_type),
+            busy_wait.eq(self.cmd_command.fields.busy_wait),
             cmd.eq(self.cmd_command.fields.cmd),
 
             # Encode Cmd Event to Register.
@@ -168,6 +172,7 @@ class SDCore(Module, AutoCSR):
             phy.cmdr.sink.valid.eq(1),
             phy.cmdr.sink.cmd_type.eq(cmd_type),
             phy.cmdr.sink.data_type.eq(data_type),
+            phy.cmdr.sink.busy_wait.eq(busy_wait),
             If(cmd_type == SDCARD_CTRL_RESPONSE_LONG,
                 # 136-bit + 8-bit shift to expose expected 128-bit window to software.
                 phy.cmdr.sink.length.eq((136 + 8)//8)
@@ -190,6 +195,9 @@ class SDCore(Module, AutoCSR):
                         NextState("DATA-WRITE")
                     ).Elif(data_type == SDCARD_CTRL_DATA_TRANSFER_READ,
                         NextState("DATA-READ")
+                    # Wait for busy if required
+                    ).Elif(busy_wait,
+                        NextState("BUSY-WAIT")
                     # Else return to Idle.
                     ).Else(
                         NextState("IDLE")
@@ -198,6 +206,17 @@ class SDCore(Module, AutoCSR):
                 ).Else(
                     NextValue(cmd_response, Cat(phy.cmdr.source.data, cmd_response))
                 )
+            )
+        )
+        fsm.act("BUSY-WAIT",
+            # Wait for one more byte from the phy to indicate that the
+            # card is not busy
+            phy.cmdr.source.ready.eq(1),
+            If(phy.cmdr.source.valid,
+                If(phy.cmdr.source.status == SDCARD_STREAM_STATUS_TIMEOUT,
+                    NextValue(cmd_timeout, 1)
+                ),
+                NextState("IDLE")
             )
         )
         fsm.act("DATA-WRITE",

--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -48,6 +48,8 @@ class SDCore(Module, AutoCSR):
             CSRField("crc",     size=1, description="CRC Error."), # FIXME: Generate/Connect.
         ])
 
+        self.cmd_done = Signal()
+
         # Block Length/Count Registers.
         self.block_length = CSRStorage(10, description="Data transfer Block Length (in bytes).")
         self.block_count  = CSRStorage(32, description="Data transfer Block Count.")
@@ -100,6 +102,9 @@ class SDCore(Module, AutoCSR):
             self.cmd_event.fields.error.eq(cmd_error),
             self.cmd_event.fields.timeout.eq(cmd_timeout),
             self.cmd_event.fields.crc.eq(0),
+
+            # Publish command done signal so it can be used for an interrupt
+            self.cmd_done.eq(cmd_done),
 
             # Encode Data Event to Register.
             self.data_event.fields.done.eq(data_done),

--- a/litesdcard/gen.py
+++ b/litesdcard/gen.py
@@ -38,6 +38,9 @@ _io = [
     ("clk", 0, Pins(1)),
     ("rst", 1, Pins(1)),
 
+    # Interrupt
+    ("irq", 0, Pins(1)),
+
     # SDCard Pads.
     ("sdcard", 0,
         Subsignal("data", Pins(4)), # Note: Requires Pullup (internal or external).
@@ -82,6 +85,10 @@ class LiteSDCardCore(SoCMini):
         # SDCard -----------------------------------------------------------------------------------
         # Simply integrate SDCard through LiteX's add_sdcard method.
         self.add_sdcard(name="sdcard")
+
+        # IRQ
+        irq_pad = platform.request("irq")
+        self.comb += irq_pad.eq(self.sdirq.irq)
 
 # Build --------------------------------------------------------------------------------------------
 

--- a/litesdcard/phy.py
+++ b/litesdcard/phy.py
@@ -42,6 +42,8 @@ class SDPHYClocker(Module, AutoCSR):
         self.stop    = Signal()
         self.clk     = Signal()
         self.ce      = Signal()
+        self.sd_clk  = Signal()
+        self.clk_enb = Signal()
 
         # # #
 
@@ -59,6 +61,13 @@ class SDPHYClocker(Module, AutoCSR):
         self.comb += Case(self.divider.storage, cases)
         self.sync += self.clk.eq(clk)
         self.comb += self.ce.eq(clk & ~clk_d)
+
+        # Ensure we don't get short pulses on the SD card clock output
+        ce_delayed = Signal()
+        ce_latched = Signal()
+        self.sync += If(clk_d, ce_delayed.eq(self.clk_enb))
+        self.comb += If(clk_d, ce_latched.eq(self.clk_enb)).Else(ce_latched.eq(ce_delayed))
+        self.comb += self.sd_clk.eq(~clk & ce_latched)
 
 # SDCard PHY Read ----------------------------------------------------------------------------------
 
@@ -488,7 +497,7 @@ class SDPHYIOGen(Module):
         # Clk
         self.specials += SDROutput(
             clk = ClockSignal(),
-            i   = ~clocker.clk & sdpads.clk,
+            i   = clocker.sd_clk,
             o   = pads.clk
         )
 
@@ -536,7 +545,7 @@ class SDPHYIOGen(Module):
 class SDPHYIOEmulator(Module):
     def __init__(self, clocker, sdpads, pads):
         # Clk
-        self.comb += If(sdpads.clk, pads.clk.eq(~clocker.clk))
+        self.comb += pads.clk.eq(clocker.sd_clk)
 
         # Cmd
         self.comb += [
@@ -588,6 +597,7 @@ class SDPHY(Module, AutoCSR):
         ]
         for m in [init, cmdw, cmdr, dataw, datar]:
             self.comb += m.pads_out.ready.eq(self.clocker.ce)
+        self.comb += self.clocker.clk_enb.eq(sdpads.clk)
 
         # Connect physical pads to pads_in of submodules -------------------------------------------
         for m in [init, cmdw, cmdr, dataw, datar]:


### PR DESCRIPTION
- Provide a way to wait while the card is busy with the clock running
- Make sure we don't generate runt clock pulses
- Support interrupts
- Provide for a command-done interrupt, which is useful for long-running commands that don't transfer data, such as erase.
- Adjust the received data sampling point

With this it's working well under Linux - I can do mkfs.ext4 and use it as a root file system and seems quite robust and not too slow.
