### PR TITLE
setup.py: Add emulator/verilog/** to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setup(
     license="BSD",
     python_requires="~=3.6",
     packages=find_packages(exclude=("test*", "sim*", "doc*", "examples*")),
+    package_data={
+        "litesdcard": ["emulator/verilog/**"],
+    },
     include_package_data=True,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
After installing the suite of LiteX cores as packages in a virtual environment, I discovered that `litex_sim --with-sdcard` complains of being unable to locate the modules defined in `emulator/verilog`. Adding these files to this package's data appears to fix the problem, allowing the build to complete successfully.

If this isn't the correct way to solve my issue, let me know what you'd prefer and I'll make the requested changes.