### PR TITLE
gen.py: Export direction signals for controlling an external buffer

### DIFF
--- a/litesdcard/gen.py
+++ b/litesdcard/gen.py
@@ -49,6 +49,9 @@ _io = [
         Subsignal("cmd",  Pins(1)), # Note: Requires Pullup (internal or external).
         Subsignal("clk",  Pins(1)),
         Subsignal("cd",   Pins(1)),
+        Subsignal("cmd_dir",   Pins(1)),
+        Subsignal("dat0_dir",  Pins(1)),
+        Subsignal("dat13_dir", Pins(1)),
     ),
 ]
 


### PR DESCRIPTION
Some platforms (e.g. Lambda Concepts ECPIX-5) connect to the SD card via a buffer / level shifter, which needs these signals to indicate which way it should drive.