### PR TITLE
RFC: phy: restore operation at lower (50MHz) sys-clk-freq

### DIFF
--- a/litesdcard/phy.py
+++ b/litesdcard/phy.py
@@ -62,14 +62,14 @@ class SDPHYClocker(LiteXModule):
         # SDCard CE Generation.
         clk_d = Signal()
         self.sync += clk_d.eq(clk)
-        self.sync += self.ce.eq(clk & ~clk_d)
+        self.comb += self.ce.eq(clk & ~clk_d)
 
         # Ensure we don't get short pulses on the SDCard Clk.
         ce_delayed = Signal()
         ce_latched = Signal()
         self.sync += If(clk_d, ce_delayed.eq(self.clk_en))
         self.comb += If(clk_d, ce_latched.eq(self.clk_en)).Else(ce_latched.eq(ce_delayed))
-        self.sync += self.clk.eq(~clk & ce_latched)
+        self.comb += self.clk.eq(~clk & ce_latched)
 
 # SDCard PHY Read ----------------------------------------------------------------------------------
 


### PR DESCRIPTION
Following commit 15bc2db, LiteSDCard no longer works properly at the low end of system clock speeds (e.g., 50MHz). Reverting the way `self.ce` and `self.clk` are generated to `comb` instead of `sync`, allows LiteSDCard to operate at the full previous range of system clock speeds.

Fixes: 15bc2db

tested on nexys_video with vexriscv at 50 and 100 MHz, and with rocket at 50MHz on the nexys_video and ecpix5.