### PR TITLE
phy/SDPHYClocker: Rework Clk Divider.

### DIFF
--- a/litesdcard/phy.py
+++ b/litesdcard/phy.py
@@ -53,7 +53,7 @@ class SDPHYClocker(LiteXModule):
         count = Signal(10)
         self.sync += [
             # half = max(1, ceil((storage + 1) / 2)).
-            half.eq((self.divider.storage + 2) >> 1),
+            half.eq((self.divider.storage + 2) >> 1), # +2 compensates for the truncating >> 1.
 
             If(~self.stop,
                 If(count == 0,

--- a/litesdcard/phy.py
+++ b/litesdcard/phy.py
@@ -49,12 +49,14 @@ class SDPHYClocker(LiteXModule):
 
         # SDCard Clk Divider Generation.
         clk   = Signal()
-        half  = Signal(10) # >= 1 : half-period in sys-clk cycles.
+        half  = Signal(10, reset=1) # >= 1 : half-period in sys-clk cycles.
         count = Signal(10)
         self.sync += [
             # half = max(1, ceil((storage + 1) / 2)).
-            half.eq((self.divider.storage + 2) >> 1), # +2 compensates for the truncating >> 1.
-
+            half.eq(Mux(self.divider.storage < 2,
+                1,                              # 0 or 1 → clamp.
+                (self.divider.storage + 1) >> 1 # ceil().
+            )),
             If(~self.stop,
                 If(count == 0,
                     clk.eq(~clk),          # 50 % duty-cycle toggle.

--- a/litesdcard/phy.py
+++ b/litesdcard/phy.py
@@ -49,17 +49,19 @@ class SDPHYClocker(LiteXModule):
 
         # SDCard Clk Divider Generation.
         clk   = Signal()
-        half  = Signal(10, reset=1) # >= 1 : half-period in sys-clk cycles.
+        half  = Signal(10) # >= 1 : half-period in sys-clk cycles.
         count = Signal(10)
+
+        # half = max(1, ceil((storage + 1) / 2)).
+        self.comb += half.eq((self.divider.storage + 1) >> 1)
+
         self.sync += [
-            # half = max(1, ceil((storage + 1) / 2)).
-            half.eq((self.divider.storage + 1) >> 1),
             If(~self.stop,
                 If(count <= 1,
-                    clk.eq(~clk),          # 50 % duty-cycle toggle.
-                    count.eq(half)         # reload.
+                    clk.eq(~clk),       # 50 % duty-cycle toggle.
+                    count.eq(half)      # reload count.
                 ).Else(
-                    count.eq(count - 1)    # simple down-count.
+                    count.eq(count - 1) # simple down-count.
                 )
             )
         ]

--- a/litesdcard/phy.py
+++ b/litesdcard/phy.py
@@ -53,14 +53,11 @@ class SDPHYClocker(LiteXModule):
         count = Signal(10)
         self.sync += [
             # half = max(1, ceil((storage + 1) / 2)).
-            half.eq(Mux(self.divider.storage < 2,
-                1,                              # 0 or 1 → clamp.
-                (self.divider.storage + 1) >> 1 # ceil().
-            )),
+            half.eq((self.divider.storage + 1) >> 1),
             If(~self.stop,
-                If(count == 0,
+                If(count <= 1,
                     clk.eq(~clk),          # 50 % duty-cycle toggle.
-                    count.eq(half - 1)     # reload N-1 → total phase = N.
+                    count.eq(half)         # reload.
                 ).Else(
                     count.eq(count - 1)    # simple down-count.
                 )

--- a/test/test_phy.py
+++ b/test/test_phy.py
@@ -57,8 +57,8 @@ class TestPHY(unittest.TestCase):
     def test_clocker_div3(self):
         # Effective Div = 4.
         def gen(dut):
-            clk   = "__--__--__--__--"
-            ce    = "_-__-___-___-___"
+            clk   = "___--__--__--__--"
+            ce    = "_-___-___-___-___"
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
                 self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
@@ -70,8 +70,8 @@ class TestPHY(unittest.TestCase):
     def test_clocker_div4(self):
         # Effective Div = 4.
         def gen(dut):
-            clk   = "__--__--__--__--"
-            ce    = "_-__-___-___-___"
+            clk   = "___--__--__--__--"
+            ce    = "_-___-___-___-___"
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
                 self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
@@ -83,8 +83,8 @@ class TestPHY(unittest.TestCase):
     def test_clocker_div5(self):
         # Effective Div = 6.
         def gen(dut):
-            clk   = "__---___---___---_"
-            ce    = "_-___-_____-_____-"
+            clk   = "____---___---___---_"
+            ce    = "_-_____-_____-_____-"
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
                 self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
@@ -97,8 +97,8 @@ class TestPHY(unittest.TestCase):
         # Effective Div = 8.
         def gen(dut):
             yield dut.divider.storage.eq(8)
-            clk   = "__----____----___"
-            ce    = "_-____-_______-__"
+            clk   = "_____----____----___"
+            ce    = "_-_______-_______-__"
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
                 self.assertEqual(c2bool(ce[i]),    (yield dut.ce))

--- a/test/test_phy.py
+++ b/test/test_phy.py
@@ -15,40 +15,96 @@ def c2bool(c):
 
 
 class TestPHY(unittest.TestCase):
-    def test_clocker_div2(self):
+    def test_clocker_div0(self):
+        # Effective Div = 2.
         def gen(dut):
-            yield dut.divider.storage.eq(2)
-            clk   = "___-_-_-_-_-_-_-_"
-            ce    = "__-_-_-_-_-_-_-_-"
+            clk   = "__-_-_-_-_-_-_-_"
+            ce    = "_-_-_-_-_-_-_-_-"
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
                 self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
                 yield
         dut = SDPHYClocker()
+        dut.divider.storage.reset = 0
+        run_simulation(dut, gen(dut))
+
+    def test_clocker_div1(self):
+        # Effective Div = 2.
+        def gen(dut):
+            clk   = "__-_-_-_-_-_-_-_"
+            ce    = "_-_-_-_-_-_-_-_-"
+            for i in range(len(clk)):
+                self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
+                self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
+                yield
+        dut = SDPHYClocker()
+        dut.divider.storage.reset = 1
+        run_simulation(dut, gen(dut))
+
+    def test_clocker_div2(self):
+        # Effective Div = 2.
+        def gen(dut):
+            clk   = "__-_-_-_-_-_-_-_"
+            ce    = "_-_-_-_-_-_-_-_-"
+            for i in range(len(clk)):
+                self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
+                self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
+                yield
+        dut = SDPHYClocker()
+        dut.divider.storage.reset = 2
+        run_simulation(dut, gen(dut))
+
+    def test_clocker_div3(self):
+        # Effective Div = 4.
+        def gen(dut):
+            clk   = "__--__--__--__--"
+            ce    = "_-__-___-___-___"
+            for i in range(len(clk)):
+                self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
+                self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
+                yield
+        dut = SDPHYClocker()
+        dut.divider.storage.reset = 3
         run_simulation(dut, gen(dut))
 
     def test_clocker_div4(self):
+        # Effective Div = 4.
         def gen(dut):
-            yield dut.divider.storage.eq(4)
-            clk   = "____--__--__--__-"
-            ce    = "__-___-___-___-__"
+            clk   = "__--__--__--__--"
+            ce    = "_-__-___-___-___"
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
                 self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
                 yield
         dut = SDPHYClocker()
+        dut.divider.storage.reset = 4
+        run_simulation(dut, gen(dut))
+
+    def test_clocker_div5(self):
+        # Effective Div = 6.
+        def gen(dut):
+            clk   = "__---___---___---_"
+            ce    = "_-___-_____-_____-"
+            for i in range(len(clk)):
+                self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
+                self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
+                yield
+        dut = SDPHYClocker()
+        dut.divider.storage.reset = 5
         run_simulation(dut, gen(dut))
 
     def test_clocker_div8(self):
+        # Effective Div = 8.
         def gen(dut):
             yield dut.divider.storage.eq(8)
-            clk   = "________----____----"
-            ce    = "____-_______-_______"
+            clk   = "__----____----___"
+            ce    = "_-____-_______-__"
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]),   (yield dut.clk))
                 self.assertEqual(c2bool(ce[i]),    (yield dut.ce))
                 yield
         dut = SDPHYClocker()
+        dut.divider.storage.reset = 8
         run_simulation(dut, gen(dut))
 
     def test_phyr_cmd(self):


### PR DESCRIPTION
- Ensure frequency is always <= configured frequency (fix issue with odd cases).
- Simplify logic to use down counter.
- Cover more cases in unit-test (and also test odd cases).

Original PR: https://github.com/enjoy-digital/litesdcard/pull/39.