### PR TITLE
core: move block delimiter into core

### DIFF
--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -116,6 +116,16 @@ class SDCore(LiteXModule):
             crc7_inserter.enable.eq(1),
         ]
 
+        # Block delimiter for DATA-WRITE
+        count = Signal(9)
+        self.sync += [
+            If(self.sink.valid & self.sink.ready,
+                count.eq(count + 1),
+                If(self.sink.last, count.eq(0))
+            )
+        ]
+        self.comb += If(count == (block_length - 1), self.sink.last.eq(1))
+
         # IRQ / Generate IRQ on CMD done rising edge
         done_d     = Signal()
         self.sync += done_d.eq(cmd_done)

--- a/litesdcard/frontend/dma.py
+++ b/litesdcard/frontend/dma.py
@@ -86,16 +86,6 @@ class SDMem2BlockDMA(LiteXModule):
             fifo.source.connect(self.source),
         ]
 
-        # Block delimiter
-        count = Signal(9)
-        self.sync += [
-            If(self.source.valid & self.source.ready,
-                count.eq(count + 1),
-                If(self.source.last, count.eq(0))
-            )
-        ]
-        self.comb += If(count == (512 - 1), self.source.last.eq(1))
-
         # IRQ / Generate IRQ on DMA done rising edge
         done_d = Signal()
         self.sync += done_d.eq(self.dma._done.status)


### PR DESCRIPTION
move block delimiter, so we can
use the block_length from the csr
instead of the hardcoded 512.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>