### PR TITLE
phy: datar: shorten clk cycles

### DIFF
--- a/litesdcard/phy.py
+++ b/litesdcard/phy.py
@@ -584,7 +584,7 @@ class SDPHYDATAR(LiteXModule):
                         sink.ready.eq(1),
                         If(sink.last,
                             NextValue(count, 0),
-                            NextState("CLK40")
+                            NextState("CLK8")
                         ).Else(
                             NextState("IDLE")
                         )
@@ -599,11 +599,11 @@ class SDPHYDATAR(LiteXModule):
                 NextState("TIMEOUT")
             )
         )
-        fsm.act("CLK40",
+        fsm.act("CLK8",
             pads_out.clk.eq(1),
             If(pads_out.ready,
                 NextValue(count, count + 1),
-                If(count == (40-1),
+                If(count == (8-1),
                     NextState("IDLE")
                 )
             )


### PR DESCRIPTION
according to sd and mcc specification
only 8 clock cycles are reguired before
shutting the clock down, not 40.
These 40 clk cycels are in this since the
initial commit. So I don't know why.

Works on hw.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>