### PR TITLE
Fix verilog emulator sources not present when using non-editable install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include litesdcard/emulator/verilog *


### PR DESCRIPTION
All non-py files to be installed need to explicitly listed.

For editable install (as used in `litex_setup.py`) this error does not appear