### PR TITLE
Fix installation via pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include litesdcard/emulator/verilog *


### PR DESCRIPTION
When installing via pip (for example `pip install git+https://github.com/enjoy-digital/litex`), only python files get installed automatically. This breaks the emulator since it requires verilog files to be present.

The merge request instructs pip to also install those verilog files.