### PR TITLE
core: Report read CRC errors from data reader

### DIFF
--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -284,7 +284,7 @@ class SDCore(LiteXModule):
                             NextState("IDLE")
                         )
                     ),
-                    If(phy.dataw.source.status == SDCARD_STREAM_STATUS_CRCERROR,
+                    If(phy.datar.source.status == SDCARD_STREAM_STATUS_CRCERROR,
                         NextValue(data_crc, 1),
                     ),
                 # On Timeout: set Data Timeout and return to Idle.


### PR DESCRIPTION
## Summary
- check the read-side PHY status in the DATA-READ path when raising the data CRC event
- keep the write-side status checks limited to the DATA-WRITE path

## Testing
- pytest -q: 17 passed
- rebuilt an SDCard-enabled LiteX bitstream for the ALTER SO-DIMM DDR5 tester target
- loaded the bitstream on hardware and confirmed the SDCard is detected and initializes

## Hardware note
This fixes a read-path status typo, but it does not by itself fix the remaining SDCard read instability seen on the tested board: the default initialization path still gives inconsistent sector reads, while a conservative forced 1-bit initialization path reads sector 0 consistently.