### PR TITLE
core: receive read data during command response

### DIFF
--- a/litesdcard/core.py
+++ b/litesdcard/core.py
@@ -80,12 +80,20 @@ class SDCore(LiteXModule):
 
         data_type    = Signal(2)
         data_count   = Signal(32)
+        data_read_count = Signal(32)
         data_done    = Signal()
         data_error   = Signal()
         data_timeout = Signal()
         data_crc     = Signal()
 
         cmd          = Signal(6)
+
+        data_read_fifo = ResetInserter()(stream.SyncFIFO(
+            [("data", 8), ("status", 3), ("drop", 1)],
+            depth=64,
+        ))
+        self.submodules.data_read_fifo = data_read_fifo
+        self.comb += phy.datar.source.connect(data_read_fifo.sink)
 
         self.comb += [
             # Decode type of Cmd/Data from Register.
@@ -130,6 +138,8 @@ class SDCore(LiteXModule):
             NextValue(data_done,  1),
             NextValue(cmd_count,  0),
             NextValue(data_count, 0),
+            NextValue(data_read_count, 0),
+            data_read_fifo.reset.eq(1),
             crc7_inserter.reset.eq(1),
             # Wait for a valid Cmd.
             If(cmd_send,
@@ -191,6 +201,17 @@ class SDCore(LiteXModule):
             ).Else(
                 # 48-bit 6 bytes.
                 phy.cmdr.sink.length.eq(48//8)
+            ),
+
+            # Start looking for read data in parallel with the command response. Some cards
+            # can drive DAT before the CMD response has fully completed.
+            If(data_type == SDCARD_CTRL_DATA_TRANSFER_READ,
+                phy.datar.sink.valid.eq(data_read_count != block_count),
+                phy.datar.sink.block_length.eq(block_length),
+                phy.datar.sink.last.eq(data_read_count == (block_count - 1)),
+                If(phy.datar.sink.ready,
+                    NextValue(data_read_count, data_read_count + 1),
+                ),
             ),
 
             # Receive the Cmd Response from the PHY.
@@ -260,23 +281,26 @@ class SDCore(LiteXModule):
         )
         fsm.act("DATA-READ",
             # Send Data Response information to the PHY.
-            phy.datar.sink.valid.eq(1),
+            phy.datar.sink.valid.eq(data_read_count != block_count),
             phy.datar.sink.block_length.eq(block_length),
-            phy.datar.sink.last.eq(data_count == (block_count - 1)),
+            phy.datar.sink.last.eq(data_read_count == (block_count - 1)),
+            If(phy.datar.sink.ready,
+                NextValue(data_read_count, data_read_count + 1),
+            ),
 
             # Receive Data Response and Status from the PHY.
-            If(phy.datar.source.valid,
+            If(data_read_fifo.source.valid,
                 # On valid Data:
-                If((phy.datar.source.status == SDCARD_STREAM_STATUS_OK) |
-                   (phy.datar.source.status == SDCARD_STREAM_STATUS_CRCERROR),
+                If((data_read_fifo.source.status == SDCARD_STREAM_STATUS_OK) |
+                   (data_read_fifo.source.status == SDCARD_STREAM_STATUS_CRCERROR),
                     # Receive Data and drop CRC part.
-                    If(phy.datar.source.drop,
-                        phy.datar.source.ready.eq(1)
+                    If(data_read_fifo.source.drop,
+                        data_read_fifo.source.ready.eq(1)
                     ).Else(
-                        phy.datar.source.connect(self.source, omit={"status", "drop"}),
+                        data_read_fifo.source.connect(self.source, omit={"status", "drop"}),
                     ),
                     # On last Data:
-                    If(phy.datar.source.last & phy.datar.source.ready,
+                    If(data_read_fifo.source.last & data_read_fifo.source.ready,
                         # Increment Data Count.
                         NextValue(data_count, data_count + 1),
                         # Transfer is Done when Data Count reaches Block Count.
@@ -284,13 +308,13 @@ class SDCore(LiteXModule):
                             NextState("IDLE")
                         )
                     ),
-                    If(phy.datar.source.status == SDCARD_STREAM_STATUS_CRCERROR,
+                    If(data_read_fifo.source.status == SDCARD_STREAM_STATUS_CRCERROR,
                         NextValue(data_crc, 1),
                     ),
                 # On Timeout: set Data Timeout and return to Idle.
-                ).Elif(phy.datar.source.status == SDCARD_STREAM_STATUS_TIMEOUT,
+                ).Elif(data_read_fifo.source.status == SDCARD_STREAM_STATUS_TIMEOUT,
                     NextValue(data_timeout, 1),
-                    phy.datar.source.ready.eq(1),
+                    data_read_fifo.source.ready.eq(1),
                     NextState("IDLE")
                 )
             )

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,0 +1,115 @@
+#
+# This file is part of LiteSDCard.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.soc.interconnect import stream
+
+from litesdcard.common import *
+from litesdcard.core import SDCore
+
+
+class _FakePHY:
+    def __init__(self):
+        self.cmdw = _EndpointPair(
+            sink_layout=[("data", 8), ("cmd_type", 2)],
+        )
+        self.cmdr = _EndpointPair(
+            sink_layout=[("cmd_type", 2), ("data_type", 2), ("length", 8)],
+            source_layout=[("data", 8), ("status", 3)],
+        )
+        self.dataw = _EndpointPair(
+            sink_layout=[("data", 8), ("last_block", 1)],
+            source_layout=[("status", 3)],
+        )
+        self.datar = _EndpointPair(
+            sink_layout=[("block_length", 10)],
+            source_layout=[("data", 8), ("status", 3), ("drop", 1)],
+        )
+
+
+class _EndpointPair:
+    def __init__(self, sink_layout, source_layout=None):
+        self.sink = stream.Endpoint(sink_layout)
+        if source_layout is not None:
+            self.source = stream.Endpoint(source_layout)
+
+
+class TestSDCore(unittest.TestCase):
+    def test_read_data_reception_starts_during_cmd_response(self):
+        phy = _FakePHY()
+        dut = SDCore(phy)
+
+        early_datar_start = []
+        read_data         = []
+
+        def host_gen():
+            yield dut.block_length.storage.eq(1)
+            yield dut.block_count.storage.eq(1)
+            yield dut.cmd_command.fields.cmd_type.eq(SDCARD_CTRL_RESPONSE_SHORT)
+            yield dut.cmd_command.fields.data_type.eq(SDCARD_CTRL_DATA_TRANSFER_READ)
+            yield dut.cmd_command.fields.cmd.eq(17)
+            yield dut.source.ready.eq(1)
+            yield dut.cmd_send.wr_stb.eq(1)
+            yield
+            yield dut.cmd_send.wr_stb.eq(0)
+
+            for _ in range(128):
+                if (yield dut.source.valid):
+                    read_data.append((yield dut.source.data))
+                    break
+                yield
+
+        def cmdw_gen():
+            yield phy.cmdw.sink.ready.eq(1)
+            for _ in range(128):
+                yield
+
+        def cmdr_gen():
+            response = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66]
+            while (yield phy.cmdr.sink.valid) == 0:
+                yield
+
+            for i, data in enumerate(response):
+                yield phy.cmdr.source.data.eq(data)
+                yield phy.cmdr.source.status.eq(SDCARD_STREAM_STATUS_OK)
+                yield phy.cmdr.source.last.eq(i == len(response) - 1)
+                yield phy.cmdr.source.valid.eq(1)
+                if i < len(response) - 1 and (yield phy.datar.sink.valid):
+                    early_datar_start.append(True)
+                yield
+                while (yield phy.cmdr.source.ready) == 0:
+                    yield
+                yield phy.cmdr.source.valid.eq(0)
+                yield
+
+        def datar_gen():
+            while (yield phy.datar.sink.valid) == 0:
+                yield
+
+            yield phy.datar.source.data.eq(0xa5)
+            yield phy.datar.source.status.eq(SDCARD_STREAM_STATUS_OK)
+            yield phy.datar.source.drop.eq(0)
+            yield phy.datar.source.first.eq(1)
+            yield phy.datar.source.last.eq(1)
+            yield phy.datar.source.valid.eq(1)
+            while (yield phy.datar.source.ready) == 0:
+                yield
+            yield phy.datar.sink.ready.eq(1)
+            yield
+            yield phy.datar.source.valid.eq(0)
+            yield phy.datar.sink.ready.eq(0)
+
+        run_simulation(dut, [host_gen(), cmdw_gen(), cmdr_gen(), datar_gen()])
+
+        self.assertEqual(early_datar_start, [True])
+        self.assertEqual(read_data, [0xa5])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Start arming the read data path while CMD responses are still being received so cards that assert DAT early are not missed.

Buffer PHY read-data output in SDCore until the command response path completes, then drain it through the existing source stream.

Add a regression for issue #26 where data reception must start before the last response byte.